### PR TITLE
Revert "Ads supports date-trunc so we simply use it"

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -186,28 +186,52 @@
   (hx/->time time-value))
 
 
-(defn- date-trunc [unit expr] (hsql/call :date_trunc (hx/literal unit) (hx/->timestamp expr)))
+;; Since MySQL doesn't have date_trunc() we fake it by formatting a date to an appropriate string and then converting
+;; back to a date. See http://dev.mysql.com/doc/refman/5.6/en/date-and-time-functions.html#function_date-format for an
+;; explanation of format specifiers
+(defn- trunc-with-format [format-str expr]
+  (str-to-date format-str (date-format format-str expr)))
 
 
 (defmethod sql.qp/date [:mysql :default]         [_ _ expr] expr)
-(defmethod sql.qp/date [:mysql :minute]          [_ _ expr] (date-trunc :minute expr))
+(defmethod sql.qp/date [:mysql :minute]          [_ _ expr] (trunc-with-format "%Y-%m-%d %H:%i" expr))
 (defmethod sql.qp/date [:mysql :minute-of-hour]  [_ _ expr] (hx/minute expr))
-(defmethod sql.qp/date [:mysql :hour]            [_ _ expr] (date-trunc :hour expr))
+(defmethod sql.qp/date [:mysql :hour]            [_ _ expr] (trunc-with-format "%Y-%m-%d %H" expr))
 (defmethod sql.qp/date [:mysql :hour-of-day]     [_ _ expr] (hx/hour expr))
 (defmethod sql.qp/date [:mysql :day]             [_ _ expr] (hsql/call :date expr))
 (defmethod sql.qp/date [:mysql :day-of-week]     [_ _ expr] (hsql/call :dayofweek expr))
 (defmethod sql.qp/date [:mysql :day-of-month]    [_ _ expr] (hsql/call :dayofmonth expr))
 (defmethod sql.qp/date [:mysql :day-of-year]     [_ _ expr] (hsql/call :dayofyear expr))
-(defmethod sql.qp/date [:mysql :week]            [_ _ expr] (date-trunc :week expr))
-(defmethod sql.qp/date [:mysql :month]           [_ _ expr] (date-trunc :month expr))
 (defmethod sql.qp/date [:mysql :month-of-year]   [_ _ expr] (hx/month expr))
-(defmethod sql.qp/date [:mysql :quarter]         [_ _ expr] (date-trunc :quarter expr))
 (defmethod sql.qp/date [:mysql :quarter-of-year] [_ _ expr] (hx/quarter expr))
 (defmethod sql.qp/date [:mysql :year]            [_ _ expr] (hx/year expr))
+
+;; To convert a YEARWEEK (e.g. 201530) back to a date you need tell MySQL which day of the week to use,
+;; because otherwise as far as MySQL is concerned you could be talking about any of the days in that week
+(defmethod sql.qp/date [:mysql :week] [_ _ expr]
+  (str-to-date "%X%V %W"
+               (hx/concat (hsql/call :yearweek expr)
+                          (hx/literal " Sunday"))))
 
 ;; mode 6: Sunday is first day of week, first week of year is the first one with 4+ days
 (defmethod sql.qp/date [:mysql :week-of-year] [_ _ expr]
   (hx/inc (hx/week expr 6)))
+
+(defmethod sql.qp/date [:mysql :month] [_ _ expr]
+  (str-to-date "%Y-%m-%d"
+               (hx/concat (date-format "%Y-%m" expr)
+                          (hx/literal "-01"))))
+
+;; Truncating to a quarter is trickier since there aren't any format strings.
+;; See the explanation in the H2 driver, which does the same thing but with slightly different syntax.
+(defmethod sql.qp/date [:mysql :quarter] [_ _ expr]
+  (str-to-date "%Y-%m-%d"
+               (hx/concat (hx/year expr)
+                          (hx/literal "-")
+                          (hx/- (hx/* (hx/quarter expr)
+                                      3)
+                                2)
+                          (hx/literal "-01"))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This reverts commit 8f407172be4e95d58c760ae717d38d6371c2c71d.



###### Before submitting the PR, please make sure you do the following
- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
